### PR TITLE
Fix Windows session loading compatibility issues

### DIFF
--- a/electron/fileSystem.ts
+++ b/electron/fileSystem.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs'
-import { join, basename } from 'path'
+import { join, basename, resolve, isAbsolute } from 'path'
 import { homedir } from 'os'
 import { resolveProjectPath } from './pathResolver'
 
@@ -61,10 +61,11 @@ export async function getProjects(): Promise<Project[]> {
   }
 }
 
+
 export async function getSessions(projectName: string): Promise<Session[]> {
   try {
     // Check if projectName is a project name or full path
-    const projectPath = projectName.startsWith('/') 
+    const projectPath = isAbsolute(projectName)
       ? projectName 
       : join(CLAUDE_PROJECTS_PATH, projectName.replace(/\//g, '-'))
     

--- a/electron/pathResolver.ts
+++ b/electron/pathResolver.ts
@@ -53,13 +53,127 @@ export function resolveProjectPath(projectName: string): string {
     }
   }
 
+  // Array to construct result path
+  const parts: string[] = []
+  
   // Remove first '-' as it represents root (Unix paths only)
   let remaining = projectName.substring(1)
   
-  // Simple approach: replace all '-' with path separator
-  // This works for most cases and is much simpler than the complex file existence checking
-  const pathParts = remaining.split('-')
-  const result = resolve(sep, ...pathParts)
+  // Handle empty directory names (starting with --)
+  while (remaining.startsWith('-')) {
+    // Consecutive '-' means empty directory
+    parts.push('')
+    remaining = remaining.substring(1)
+  }
+  
+  // Path constructed so far
+  let currentPath = sep
+  
+  while (remaining.length > 0) {
+    // Find next '-' position
+    let nextDashIndex = remaining.indexOf('-')
+    
+    if (nextDashIndex === -1) {
+      // If no more '-', treat the rest as one part
+      parts.push(remaining)
+      currentPath = join(currentPath, remaining)
+      break
+    }
+    
+    // Check path when '-' is replaced with path separator
+    const possiblePart = remaining.substring(0, nextDashIndex)
+    const possiblePathAsSlash = join(currentPath, possiblePart)
+    
+    // Also check path when '-' is replaced with '_'
+    const possiblePathAsUnderscore = join(currentPath, possiblePart.replace(/-/g, '_'))
+    
+    // Resolve paths to handle Windows drive letters and normalize
+    const resolvedPathAsSlash = resolve(possiblePathAsSlash)
+    const resolvedPathAsUnderscore = resolve(possiblePathAsUnderscore)
+    
+    if (existsSync(resolvedPathAsSlash)) {
+      // If directory exists, separate with path separator
+      parts.push(possiblePart)
+      currentPath = possiblePathAsSlash
+      remaining = remaining.substring(nextDashIndex + 1)
+    } else if (existsSync(resolvedPathAsUnderscore)) {
+      // If exists when replaced with '_', process with '_'
+      parts.push(possiblePart.replace(/-/g, '_'))
+      currentPath = possiblePathAsUnderscore
+      remaining = remaining.substring(nextDashIndex + 1)
+    } else {
+      // If directory doesn't exist, include up to next '-' as one part
+      // Example: claude-code-web case
+      let foundValid = false
+      let searchIndex = nextDashIndex + 1
+      
+      while (searchIndex < remaining.length) {
+        const nextSearchIndex = remaining.indexOf('-', searchIndex)
+        if (nextSearchIndex === -1) {
+          // Search to the end
+          const testPart = remaining
+          const testPath = join(currentPath, testPart)
+          const testPartWithUnderscore = testPart.replace(/-/g, '_')
+          const testPathWithUnderscore = join(currentPath, testPartWithUnderscore)
+          
+          // Resolve paths for Windows compatibility
+          const resolvedTestPath = resolve(testPath)
+          const resolvedTestPathWithUnderscore = resolve(testPathWithUnderscore)
+          
+          if (existsSync(resolvedTestPath)) {
+            parts.push(testPart)
+            currentPath = testPath
+            remaining = ''
+            foundValid = true
+          } else if (existsSync(resolvedTestPathWithUnderscore)) {
+            parts.push(testPartWithUnderscore)
+            currentPath = testPathWithUnderscore
+            remaining = ''
+            foundValid = true
+          }
+          break
+        }
+        
+        // Test including up to next '-'
+        const testPart = remaining.substring(0, nextSearchIndex)
+        const testPath = join(currentPath, testPart)
+        
+        // Also test path with '_'
+        const testPartWithUnderscore = testPart.replace(/-/g, '_')
+        const testPathWithUnderscore = join(currentPath, testPartWithUnderscore)
+        
+        // Resolve paths for Windows compatibility  
+        const resolvedTestPath = resolve(testPath)
+        const resolvedTestPathWithUnderscore = resolve(testPathWithUnderscore)
+        
+        if (existsSync(resolvedTestPath)) {
+          parts.push(testPart)
+          currentPath = testPath
+          remaining = remaining.substring(nextSearchIndex + 1)
+          foundValid = true
+          break
+        } else if (existsSync(resolvedTestPathWithUnderscore)) {
+          parts.push(testPartWithUnderscore)
+          currentPath = testPathWithUnderscore
+          remaining = remaining.substring(nextSearchIndex + 1)
+          foundValid = true
+          break
+        }
+        
+        searchIndex = nextSearchIndex + 1
+      }
+      
+      if (!foundValid) {
+        // If nothing matches, treat the whole as one
+        parts.push(remaining)
+        currentPath = join(currentPath, remaining)
+        break
+      }
+    }
+  }
+  
+  // Use the currentPath as the result since it's already built correctly
+  const result = currentPath
   
   // Save to cache
   pathCache.set(projectName, result)

--- a/src/components/ProjectList/ProjectList.tsx
+++ b/src/components/ProjectList/ProjectList.tsx
@@ -26,7 +26,13 @@ export const ProjectList: React.FC<ProjectListProps> = ({ searchQuery = '' }) =>
       // Create a project tab to show session list
       createProjectTab(project.name) // Use real path for tab
     } catch (error) {
-      console.error('Error loading sessions:', error)
+      console.error('[ProjectList] Failed to load sessions for project:', project.name)
+      console.error('[ProjectList] Error:', error.message)
+      console.error('[ProjectList] Project path:', project.path)
+      
+      // Still set empty sessions to prevent loading state issues
+      setSessions([])
+      setSessionsForProject(project.name, [])
     }
   }
   
@@ -42,8 +48,8 @@ export const ProjectList: React.FC<ProjectListProps> = ({ searchQuery = '' }) =>
             borderRadius: '8px',
             cursor: 'pointer',
             transition: 'background-color 0.2s ease',
-            background: selectedProjectPath === project.path ? 'var(--secondary)' : 'transparent',
-            border: selectedProjectPath === project.path ? '1px solid var(--border)' : '1px solid transparent'
+            background: selectedProjectPath === project.name ? 'var(--secondary)' : 'transparent',
+            border: selectedProjectPath === project.name ? '1px solid var(--border)' : '1px solid transparent'
           }}
           className="project-item"
         >


### PR DESCRIPTION
## Summary

This PR fixes Windows compatibility issues where the application showed "Project 3 sessions" in the sidebar but displayed "0 sessions" when clicked. The root cause was Unix-specific path detection logic that failed to recognize Windows absolute paths.

## Issues Fixed

- **Session Loading Bug**: On Windows, projects would show session counts in the sidebar but fail to load sessions when selected
- **Path Display**: Windows project folder names like `C--Users-David-Wei-bin` now display as readable paths `C:\Users\David\Wei\bin`  
- **Cross-platform Compatibility**: Path detection now works correctly on both Unix and Windows systems
- **Intelligent Path Resolution**: Maintains the original smart path detection that handles complex project names (e.g., `happy_notes`, `claude-code-web`)

## Root Cause

The core issue was in `electron/fileSystem.ts:68` where `projectName.startsWith('/')` was used to detect absolute paths. This Unix-specific check failed on Windows where absolute paths start with drive letters (e.g., `C:\`).

## Changes Made

### 1. Enhanced Cross-platform Path Resolution ([c636b42](https://github.com/shukebeta/claude-code-viewer/commit/c636b42))
- **fileSystem.ts**: Replaced `projectName.startsWith('/')` with `path.isAbsolute()` for proper cross-platform absolute path detection
- **pathResolver.ts**: Added Windows project folder support to convert encoded names like `C--Users-username-project` to readable paths `C:\Users\username\project`
- **ProjectList.tsx**: Fixed selection state comparison logic to use consistent project identifiers

### 2. Code Cleanup ([9a33dbe](https://github.com/shukebeta/claude-code-viewer/commit/9a33dbe))
- Removed debug logging from session finder
- Cleaned up development-specific code for production readiness

### 3. Path Resolution Refinements ([000e6bf](https://github.com/shukebeta/claude-code-viewer/commit/000e6bf), [1ede569](https://github.com/shukebeta/claude-code-viewer/commit/1ede569))
- Initially attempted to simplify Unix path resolution but discovered it broke intelligent path detection
- Restored the original file existence checking logic while maintaining Windows compatibility
- The complex logic is necessary to correctly handle ambiguous cases (e.g., `happy-notes` could be `happy_notes` or `happy/notes`)

## Technical Deep Dive

### Why the Complex Path Resolution Logic?

The original path resolution algorithm is sophisticated for good reason. When Claude encodes project paths:
- `/home/user/happy_notes` becomes `-home-user-happy-notes`  
- `/home/user/my-project` also becomes `-home-user-my-project`

Without checking the actual filesystem, it's impossible to know whether `happy-notes` should resolve to:
- `happy_notes` (underscore in original name)
- `happy/notes` (separate directories)
- `happy-notes` (dash in original name)

The algorithm intelligently resolves this by:
1. Testing each possibility against the actual filesystem
2. Choosing the path that actually exists
3. Handling edge cases like consecutive dashes and complex project names

### Windows Compatibility Additions

The fixes maintain this intelligent behavior while adding Windows support:
- Using `path.resolve()` to normalize paths before existence checks
- Adding Windows-specific project folder decoding
- Using `path.isAbsolute()` for cross-platform absolute path detection

## Testing

✅ **Real-world Testing**: These changes have been tested on both Linux and Windows platforms with actual Claude project sessions, including edge cases like:
- Projects with underscores (`happy_notes`)
- Projects with dashes (`my-project`)  
- Complex multi-word projects (`claude-code-viewer`)
- Windows encoded paths (`C--Users-username-project`)

**Before**: 
- Windows users experienced session loading bugs
- Path resolution could incorrectly parse project names with underscores

**After**: 
- Session loading works correctly on both platforms
- Intelligent path resolution preserved with cross-platform support
- Improved path display for Windows project folders

## Future Improvements

If this PR is accepted, I'd be happy to contribute additional improvements:
- Add testing infrastructure (Jest/Vitest setup)
- Write comprehensive unit tests for `pathResolver.ts` covering edge cases
- Add cross-platform path resolution test coverage

## Key Insight

This fix demonstrates the importance of understanding the problem domain deeply. The original "complex" path resolution logic wasn't over-engineered—it was solving real ambiguity in path encoding that simple string replacement couldn't handle. Our solution preserves this intelligence while extending it to work cross-platform.